### PR TITLE
Add carriage_price table with foreign key constraints

### DIFF
--- a/db.sql
+++ b/db.sql
@@ -3,3 +3,13 @@ CREATE DATABASE trainbookingDB;
 
 -- Use the database
 USE trainbookingDB;
+
+-- Create Table for Carriage Prices with Foreign Key Constraints
+CREATE TABLE carriage_price (
+  schedule_id INT NOT NULL,
+  carriage_class_id INT NOT NULL,
+  price DECIMAL(10, 2) NOT NULL,
+  -- Foreign key constraints
+  FOREIGN KEY (schedule_id) REFERENCES schedule(schedule_id),
+  FOREIGN KEY (carriage_class_id) REFERENCES carriage_class(carriage_class_id)
+);


### PR DESCRIPTION
This PR introduces the carriage_price table to manage ticket prices based on schedule 
(weekday, weekend, holiday) and carriage class (First Class, Economy).

- Added carriage_price table with columns: schedule_id, carriage_class_id, price
- Set foreign key constraints referencing schedule and carriage_class tables
- Included comments in db.sql to describe the purpose of the table

Fixes #7 
